### PR TITLE
Add GitHub PR creation and review commands

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,351 @@
+---
+description: "Create a GitHub Pull Request from current branch"
+argument-hint: "[base-branch]"
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash(gh:*)
+  - Bash(git:*)
+  - AskUserQuestion
+model: sonnet
+---
+
+# Create GitHub Pull Request
+
+Create a GitHub Pull Request from the current branch, with automatic title and body generation based on commits and changes.
+
+## Step 1: Prerequisites Check
+
+Before proceeding, verify the environment is properly configured:
+
+### Check gh CLI Authentication
+
+Run: `gh auth status`
+
+If the command fails or gh is not installed:
+- Display: "Error: GitHub CLI (gh) not installed. Install from https://cli.github.com/"
+- Stop execution
+
+If not authenticated:
+- Display: "Error: Not authenticated with GitHub. Run `gh auth login` to authenticate."
+- Stop execution
+
+### Verify GitHub Repository
+
+Run: `gh repo view`
+
+If this fails:
+- Display: "Error: Not in a git repository with a GitHub remote. Ensure you're in a valid GitHub repository."
+- Stop execution
+
+### Check for Uncommitted Changes
+
+Run: `git status --porcelain`
+
+If there are uncommitted changes (output is not empty):
+- Use AskUserQuestion to prompt the user:
+  ```
+  You have uncommitted changes in your working directory:
+
+  [list of changed files]
+
+  What would you like to do?
+
+  1. Commit changes before creating PR - I'll help you create a commit first
+  2. Stash changes - Temporarily stash changes and proceed
+  3. Continue anyway - Create PR with only committed changes
+  4. Cancel - Stop and let me handle changes manually
+
+  Please select an option (1-4):
+  ```
+
+Based on user response:
+- **Option 1**: Guide user through commit creation, then continue
+- **Option 2**: Run `git stash` and continue
+- **Option 3**: Continue with PR creation
+- **Option 4**: Display "PR creation cancelled." and stop execution
+
+## Step 2: Branch Validation
+
+### Get Current Branch
+
+Run: `git branch --show-current`
+
+Store the current branch name.
+
+If on `main` or `master`:
+- Display: "Error: Cannot create PR from the default branch. Switch to a feature branch first."
+- Stop execution
+
+### Determine Base Branch
+
+Check `$ARGUMENTS` for base branch:
+
+```
+Base branch argument: $ARGUMENTS
+```
+
+**If $ARGUMENTS is provided and not empty:**
+- Use the provided value as the base branch
+- Verify it exists: `git rev-parse --verify origin/$ARGUMENTS`
+- If not found, display: "Error: Base branch '$ARGUMENTS' not found on remote."
+- Stop execution if not found
+
+**If $ARGUMENTS is empty:**
+- Detect default branch: `gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'`
+- Use the detected default branch (typically `main` or `master`)
+
+### Verify Branch Difference
+
+Run: `git log [base-branch]..HEAD --oneline`
+
+If no commits are found (output is empty):
+- Display: "Error: No commits found between '[base-branch]' and current branch '[current-branch]'. Make some commits first."
+- Stop execution
+
+### Check Remote Tracking
+
+Run: `git rev-parse --abbrev-ref @{upstream} 2>/dev/null`
+
+Store whether the branch has an upstream set:
+- If command succeeds: Branch is tracked remotely
+- If command fails: Branch needs to be pushed
+
+## Step 3: Analyze Changes
+
+### Get Commit Information
+
+Run: `git log [base-branch]..HEAD --oneline`
+
+Store the list of commits for analysis.
+
+Run: `git log [base-branch]..HEAD --format="%s"` to get commit messages.
+
+### Get Diff Statistics
+
+Run: `git diff [base-branch]...HEAD --stat`
+
+Store the diff statistics showing files changed.
+
+Run: `git diff [base-branch]...HEAD --numstat | wc -l` to count files changed.
+
+### Get Full Diff for Analysis
+
+Run: `git diff [base-branch]...HEAD`
+
+Analyze the diff to understand:
+- What types of files were changed (source, tests, docs, config)
+- The nature of changes (additions, modifications, deletions)
+
+### Detect Change Type
+
+Analyze commit messages and file changes to determine the primary change type:
+
+1. **Check commit message prefixes** for conventional commits:
+   - `feat:` or `feature:` -> Feature
+   - `fix:` or `bugfix:` -> Bug Fix
+   - `docs:` -> Documentation
+   - `test:` -> Tests
+   - `refactor:` -> Refactor
+   - `chore:` -> Chore
+   - `style:` -> Style
+   - `perf:` -> Performance
+
+2. **Check file patterns** if no conventional commit found:
+   - Changes in `test/`, `tests/`, `*_test.*`, `*_spec.*` -> Tests
+   - Changes in `docs/`, `*.md`, `*.rst` -> Documentation
+   - Changes in `*.yml`, `*.yaml`, `*.json`, `*.toml` (config files) -> Chore
+   - New files with significant code -> Feature
+   - Modifications to existing code -> Could be fix or refactor
+
+3. **Use branch name** as fallback:
+   - Branch starting with `feat/`, `feature/` -> Feature
+   - Branch starting with `fix/`, `bugfix/`, `hotfix/` -> Bug Fix
+   - Branch starting with `docs/` -> Documentation
+   - Branch starting with `refactor/` -> Refactor
+   - Branch starting with `chore/` -> Chore
+
+## Step 4: Generate PR Content
+
+### Generate Title
+
+Create a PR title using this priority:
+
+1. **If single commit**: Use the commit message (cleaned up)
+2. **If multiple commits with common prefix**: Use "[type]: Summary of changes"
+3. **From branch name**: Convert `feat/add-user-auth` to "Add user auth"
+
+Title formatting rules:
+- Capitalize first letter
+- Remove conventional commit prefixes (feat:, fix:, etc.) from display
+- Keep under 72 characters
+- Make it descriptive but concise
+
+### Generate Body
+
+Create a PR body with the following structure:
+
+```markdown
+## Summary
+
+[2-4 bullet points summarizing the key changes]
+
+- [Primary change description]
+- [Secondary change description]
+- [Additional notable changes]
+
+## Changes
+
+[Brief description of what was changed and why]
+
+### Files Changed
+
+[List of key files modified, grouped by type if many]
+
+## Test Plan
+
+- [ ] [Relevant test step 1]
+- [ ] [Relevant test step 2]
+- [ ] [Manual verification steps if applicable]
+
+## Commits
+
+[List of commits in this PR]
+
+---
+*Generated by create-pr command*
+```
+
+For the Summary section:
+- Analyze the diff and commits
+- Extract the main purpose of changes
+- Create concise bullet points
+
+For the Test Plan section:
+- If test files were modified: Include "Automated tests added/updated"
+- If source files changed: Include "Run test suite to verify changes"
+- Add relevant manual testing steps based on the nature of changes
+
+## Step 5: User Preview and Confirmation
+
+Display the proposed PR content to the user:
+
+```
+Pull Request Preview
+====================
+
+Title: [generated title]
+
+Base: [base-branch] <- [current-branch]
+
+Commits: [number of commits]
+
+Body:
+-----
+[generated body content]
+-----
+
+Files to be included: [count] files changed
+```
+
+Use AskUserQuestion to get user confirmation:
+
+```
+Review the proposed Pull Request above.
+
+What would you like to do?
+
+1. Create PR - Create the Pull Request with this content
+2. Edit title - Provide a different title
+3. Edit body - Provide a different body
+4. Edit both - Provide both a new title and body
+5. Cancel - Cancel PR creation
+
+Please select an option (1-5):
+```
+
+Based on user response:
+
+- **Option 1**: Proceed to Step 6
+- **Option 2**: Use AskUserQuestion to get new title, then return to preview
+- **Option 3**: Use AskUserQuestion to get new body, then return to preview
+- **Option 4**: Use AskUserQuestion to get new title and body, then return to preview
+- **Option 5**: Display "PR creation cancelled." and stop execution
+
+## Step 6: Create Pull Request
+
+### Push Branch if Needed
+
+If the branch has no upstream tracking (from Step 2):
+
+Run: `git push -u origin [current-branch]`
+
+If push fails:
+- Display the error message from git
+- Display: "Error: Failed to push branch. Check your permissions and try again."
+- Stop execution
+
+If push succeeds with upstream already set, optionally run: `git push` to ensure latest commits are pushed.
+
+### Create the Pull Request
+
+Run the gh CLI command to create the PR:
+
+```bash
+gh pr create \
+  --base "[base-branch]" \
+  --title "[final-title]" \
+  --body "$(cat <<'EOF'
+[final-body-content]
+EOF
+)"
+```
+
+If PR creation fails:
+- Display the error message from gh CLI
+- Check for common issues:
+  - "A pull request already exists" -> Display the existing PR URL
+  - Permission denied -> Suggest checking repository permissions
+- Display: "Error: Failed to create Pull Request. See error message above."
+- Stop execution
+
+### Display Success
+
+On successful creation, display:
+
+```
+Pull Request Created Successfully!
+==================================
+
+PR URL: [URL returned by gh pr create]
+
+Title: [final-title]
+Base: [base-branch] <- [current-branch]
+Files Changed: [count]
+Commits: [count]
+
+Next steps:
+- Review the PR: [URL]
+- Request reviewers if needed: gh pr edit [number] --add-reviewer [username]
+- Add labels if needed: gh pr edit [number] --add-label [label]
+```
+
+## Error Handling Reference
+
+Throughout execution, handle these error cases:
+
+| Error Condition | Message |
+|----------------|---------|
+| gh CLI not installed | "Error: GitHub CLI (gh) not installed. Install from https://cli.github.com/" |
+| Not authenticated | "Error: Not authenticated with GitHub. Run `gh auth login` to authenticate." |
+| Not in GitHub repo | "Error: Not in a git repository with a GitHub remote." |
+| On default branch | "Error: Cannot create PR from the default branch. Switch to a feature branch first." |
+| Base branch not found | "Error: Base branch '[branch]' not found on remote." |
+| No commits to PR | "Error: No commits found between '[base]' and current branch '[branch]'. Make some commits first." |
+| Push failed | "Error: Failed to push branch. Check your permissions and try again." |
+| PR already exists | "A Pull Request already exists for this branch: [existing PR URL]" |
+| PR creation failed | "Error: Failed to create Pull Request. See error message above." |
+| No argument (optional) | Use detected default branch automatically |
+
+Always provide actionable guidance when an error occurs.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -91,12 +91,12 @@ Display the PR information in a clear format:
 Check the PR state:
 
 If state is `MERGED`:
-- Display: "Notice: This PR has already been merged. Review is informational only - no review can be submitted."
-- Continue with review but skip submission step
+- Display: "Error: This PR has already been merged. Review is informational only - no review can be submitted."
+- Stop execution
 
 If state is `CLOSED`:
-- Display: "Notice: This PR has been closed without merging. Review is informational only - no review can be submitted."
-- Continue with review but skip submission step
+- Display: "Error: This PR has been closed without merging. Review is informational only - no review can be submitted."
+- Stop execution
 
 ## Step 5: Check CI Status
 
@@ -203,6 +203,8 @@ Check for:
 ### 8.2 Potential Bugs and Anti-patterns
 
 Look for:
+- Is the code correct?
+- Does it solve what it is meant for?
 - Null/undefined reference risks
 - Resource leaks (unclosed files, connections)
 - Race conditions in async code

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,443 @@
+---
+description: "Review a GitHub Pull Request"
+argument-hint: "<pr-number>"
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash(gh:*)
+  - Bash(git:*)
+  - AskUserQuestion
+model: sonnet
+---
+
+# GitHub Pull Request Review
+
+You are tasked with reviewing a GitHub Pull Request and providing a comprehensive code review with optional submission.
+
+## Step 1: Validate Argument
+
+Check that a PR number was provided:
+
+```
+PR number: $ARGUMENTS
+```
+
+If `$ARGUMENTS` is empty or not provided:
+- Display: "Error: No PR number provided. Usage: /review-pr <pr-number>"
+- Stop execution immediately
+
+If `$ARGUMENTS` is not a valid number:
+- Display: "Error: Invalid PR number. Usage: /review-pr <pr-number>"
+- Stop execution immediately
+
+## Step 2: Prerequisites Check
+
+### Check GitHub CLI Authentication
+
+Run: `gh auth status`
+
+If the command fails or gh is not installed:
+- Display: "Error: GitHub CLI (gh) not installed. Install from https://cli.github.com/"
+- Stop execution
+
+If not authenticated:
+- Display: "Error: Not authenticated with GitHub. Run `gh auth login` to authenticate."
+- Stop execution
+
+### Verify GitHub Repository
+
+Run: `gh repo view`
+
+If this fails:
+- Display: "Error: Not in a git repository with a GitHub remote. Ensure you're in a valid GitHub repository."
+- Stop execution
+
+## Step 3: Fetch PR Details
+
+Run the following command to fetch PR details:
+
+```bash
+gh pr view $ARGUMENTS --json number,title,body,author,baseRefName,headRefName,state,labels,reviewRequests,url
+```
+
+If the PR is not found:
+- Display: "Error: Pull Request #$ARGUMENTS not found in this repository"
+- Stop execution
+
+Parse the JSON response and extract all fields.
+
+## Step 4: Present PR Context
+
+Display the PR information in a clear format:
+
+```
+## Pull Request #[number]: [title]
+
+**URL:** [url]
+**Author:** [author.login]
+**State:** [state]
+**Base Branch:** [baseRefName] <- **Head Branch:** [headRefName]
+**Labels:** [labels as comma-separated list, or "None"]
+**Review Requests:** [reviewRequests as comma-separated list, or "None"]
+
+### Description
+
+[body content, or "No description provided"]
+```
+
+### Verify PR State
+
+Check the PR state:
+
+If state is `MERGED`:
+- Display: "Notice: This PR has already been merged. Review is informational only - no review can be submitted."
+- Continue with review but skip submission step
+
+If state is `CLOSED`:
+- Display: "Notice: This PR has been closed without merging. Review is informational only - no review can be submitted."
+- Continue with review but skip submission step
+
+## Step 5: Check CI Status
+
+Run: `gh pr checks $ARGUMENTS`
+
+Analyze the output:
+
+**If any checks have FAILED:**
+- Display warning:
+  ```
+  WARNING: CI checks have FAILED
+
+  Failed Checks:
+  - [list failed check names]
+
+  Recommendation: Consider requesting changes until CI passes.
+  ```
+- Continue with code review
+
+**If checks are PENDING:**
+- Display notice:
+  ```
+  Notice: CI checks are still running.
+
+  Pending Checks:
+  - [list pending check names]
+  ```
+- Continue with code review
+
+**If all checks PASSED:**
+- Display: "CI Status: All checks passed"
+- Continue with code review
+
+**If no checks configured:**
+- Display: "CI Status: No CI checks configured for this repository"
+- Continue with code review
+
+## Step 6: Get PR Changes
+
+### Fetch the Diff
+
+Run: `gh pr diff $ARGUMENTS`
+
+Store the complete diff for analysis.
+
+### Categorize Changed Files
+
+Run: `gh pr view $ARGUMENTS --json files --jq '.files[].path'`
+
+Categorize each file into:
+
+| Category | File Patterns |
+|----------|---------------|
+| Code | `.py`, `.js`, `.ts`, `.go`, `.rs`, `.java`, `.c`, `.cpp`, `.rb`, etc. |
+| Tests | `test_*.py`, `*_test.py`, `*.test.js`, `*.spec.ts`, `tests/`, `__tests__/` |
+| Documentation | `.md`, `.rst`, `.txt`, `docs/` |
+| Configuration | `.json`, `.yaml`, `.yml`, `.toml`, `.ini`, `.cfg`, `.env*`, `Dockerfile`, `Makefile` |
+| Other | Everything else |
+
+Display summary:
+```
+### Changed Files Summary
+
+**Total files changed:** N
+
+| Category | Count | Files |
+|----------|-------|-------|
+| Code | N | file1.py, file2.js |
+| Tests | N | test_file.py |
+| Documentation | N | README.md |
+| Configuration | N | pyproject.toml |
+| Other | N | ... |
+```
+
+## Step 7: Read Project Guidelines
+
+Before analyzing code, understand the project standards:
+
+### Global Instructions
+Check if `~/.claude/CLAUDE.md` exists. If it does, read it to understand global coding standards and conventions.
+
+### Project Instructions
+Check if `./CLAUDE.md` exists in the current directory. If it does, read it to understand project-specific:
+- Coding guidelines
+- Test requirements
+- Quality gates
+- Any special instructions
+
+Use these guidelines to inform your code review.
+
+## Step 8: Analyze Code Quality
+
+Review the diff for the following categories. Base your analysis on the actual changes in the PR.
+
+### 8.1 Code Style Consistency
+
+Check for:
+- Naming conventions (variables, functions, classes)
+- Formatting consistency with existing code
+- Import organization
+- Comment style and quality
+- Adherence to project's stated style guide (from CLAUDE.md)
+
+### 8.2 Potential Bugs and Anti-patterns
+
+Look for:
+- Null/undefined reference risks
+- Resource leaks (unclosed files, connections)
+- Race conditions in async code
+- Infinite loops or recursion without base case
+- Off-by-one errors
+- Hardcoded values that should be configurable
+- Dead code or unreachable code
+- Copy-paste errors
+
+### 8.3 Security Concerns
+
+Check for OWASP Top 10 and common security issues:
+- Hardcoded secrets, API keys, passwords
+- SQL injection vulnerabilities
+- Command injection risks
+- Path traversal vulnerabilities
+- Cross-site scripting (XSS) vectors
+- Insecure deserialization
+- Missing input validation
+- Sensitive data exposure in logs
+- Insecure cryptographic practices
+
+### 8.4 Test Coverage
+
+Analyze test changes:
+- Are tests added for new functionality?
+- Are tests updated for changed behavior?
+- Do tests cover edge cases?
+- Are tests meaningful (not just coverage padding)?
+- Test naming clarity
+
+If code is added but no tests:
+- Flag as concern if project requires tests (check CLAUDE.md for test requirements)
+
+### 8.5 Documentation
+
+Check for:
+- Docstrings on new public functions/classes
+- Updated README if behavior changes
+- Inline comments for complex logic
+- API documentation updates if applicable
+- Type hints present (if project requires them)
+
+### 8.6 Architecture and Design
+
+Consider:
+- SOLID principles adherence
+- Appropriate abstraction levels
+- Separation of concerns
+- Code duplication
+- Breaking changes
+- Performance implications
+
+## Step 9: Generate Review Report
+
+Compile findings into a structured report:
+
+```
+# Code Review Report
+
+## Summary
+
+[2-3 sentence summary of what this PR does]
+
+## Findings
+
+### Critical Issues (Must Fix)
+
+[Issues that should block merge - bugs, security issues, breaking changes]
+
+1. **[File:Line]** - [Description of issue]
+   - Why: [Explanation]
+   - Suggestion: [How to fix]
+
+[If none: "No critical issues found."]
+
+### Suggestions (Nice to Have)
+
+[Non-blocking improvements that would enhance the code]
+
+1. **[File:Line]** - [Description]
+   - Suggestion: [Improvement idea]
+
+[If none: "No suggestions."]
+
+### Questions (Need Clarification)
+
+[Things that are unclear or may need discussion]
+
+1. **[File:Line]** - [Question]
+
+[If none: "No questions."]
+
+### Praise (Good Practices)
+
+[Highlight things done well - encourages good practices]
+
+1. **[File:Line]** - [What was done well]
+
+[If none: Skip this section]
+
+## CI Status
+
+[Pass/Fail/Pending summary from Step 5]
+
+## Overall Assessment
+
+[One of the following:]
+- **Approve**: Code looks good, no critical issues, ready to merge
+- **Request Changes**: Critical issues must be addressed before merge
+- **Comment Only**: Questions need answers or suggestions provided for consideration
+```
+
+## Step 10: User Decision
+
+If the PR is still open (not merged or closed), use AskUserQuestion:
+
+```
+Review complete. How would you like to proceed?
+
+1. **Approve** - Submit approval with the review summary
+2. **Request Changes** - Submit review requesting changes (use if critical issues found)
+3. **Comment** - Submit as comment only (use for questions/suggestions without blocking)
+4. **Cancel** - Exit without submitting a review
+
+Enter your choice (1-4):
+```
+
+If the PR is merged or closed:
+- Display: "PR is [merged/closed]. Skipping review submission."
+- End execution
+
+## Step 11: Submit Review
+
+Based on user's choice, submit the review:
+
+### For Approve (Choice 1)
+
+```bash
+gh pr review $ARGUMENTS --approve --body "$(cat <<'EOF'
+## Code Review: Approved
+
+[Summary from report]
+
+### Highlights
+
+[Praise items if any, or general positive comments]
+
+### Minor Suggestions (Optional)
+
+[Non-critical suggestions if any]
+
+---
+*Reviewed with Claude Code*
+EOF
+)"
+```
+
+### For Request Changes (Choice 2)
+
+```bash
+gh pr review $ARGUMENTS --request-changes --body "$(cat <<'EOF'
+## Code Review: Changes Requested
+
+[Summary from report]
+
+### Critical Issues
+
+[List all critical issues with file:line references]
+
+### Additional Suggestions
+
+[Other suggestions if any]
+
+---
+*Reviewed with Claude Code*
+EOF
+)"
+```
+
+### For Comment (Choice 3)
+
+```bash
+gh pr review $ARGUMENTS --comment --body "$(cat <<'EOF'
+## Code Review: Feedback
+
+[Summary from report]
+
+### Questions
+
+[Questions that need clarification]
+
+### Suggestions
+
+[Suggestions for improvement]
+
+---
+*Reviewed with Claude Code*
+EOF
+)"
+```
+
+### For Cancel (Choice 4)
+
+- Display: "Review cancelled. No submission made."
+- End execution
+
+## Step 12: Confirmation
+
+After successful submission, display:
+
+```
+Review Submitted Successfully
+
+PR: #[number] - [title]
+URL: [pr url]
+Review Type: [Approved / Changes Requested / Comment]
+
+Your review has been posted to the pull request.
+```
+
+## Error Handling Reference
+
+Throughout execution, handle these error cases:
+
+| Error Condition | Message |
+|----------------|---------|
+| gh CLI not installed | "Error: GitHub CLI (gh) not installed. Install from https://cli.github.com/" |
+| Not authenticated | "Error: Not authenticated with GitHub. Run `gh auth login` to authenticate." |
+| Not in GitHub repo | "Error: Not in a git repository with a GitHub remote." |
+| PR not found | "Error: Pull Request #[number] not found in this repository" |
+| Invalid PR number | "Error: Invalid PR number. Usage: /review-pr <pr-number>" |
+| No argument provided | "Error: No PR number provided. Usage: /review-pr <pr-number>" |
+| Permission denied | "Error: You do not have permission to review this PR. Check your repository access." |
+| Network error | "Error: Unable to reach GitHub. Check your internet connection and try again." |
+| Review submission failed | "Error: Failed to submit review. [gh error message]" |
+
+Always provide actionable guidance when an error occurs.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,8 @@
       "Bash(git status)",
       "Bash(git diff:*)",
       "Bash(gh repo view:*)",
-      "Bash(gh issue view --help:*)"
+      "Bash(gh issue view --help:*)",
+      "Bash(tree:*)"
     ]
   }
 }


### PR DESCRIPTION
## Summary

- Added `/create-pr` command for automated GitHub Pull Request creation from current branch
- Added `/review-pr` command for comprehensive code review with optional submission
- Updated settings to include additional bash command permissions

## Changes

This PR introduces two new Claude Code commands that streamline GitHub workflows:

1. **create-pr.md**: A comprehensive command that handles PR creation with automatic title/body generation, prerequisite checks, branch validation, and user-friendly error handling
2. **review-pr.md**: A thorough PR review command that analyzes code quality, security, tests, and documentation, then allows submitting reviews directly to GitHub
3. **settings.local.json**: Added `tree` command permission to allowed bash commands

### Files Changed

**Command Definitions:**
- `.claude/commands/create-pr.md` (351 lines added)
- `.claude/commands/review-pr.md` (443 lines added)

**Configuration:**
- `.claude/settings.local.json` (1 line changed)

## Test Plan

- [ ] Test `/create-pr` command with a feature branch
- [ ] Verify PR creation with auto-generated title and body
- [ ] Test error handling (no commits, uncommitted changes, etc.)
- [ ] Test `/review-pr` command on an existing PR
- [ ] Verify review submission with different options (approve, request changes, comment)
- [ ] Verify CI status checking and file categorization

## Commits

- 302136c new commands

---
*Generated by create-pr command*